### PR TITLE
Update to hasGrandChildren Function

### DIFF
--- a/Treant.js
+++ b/Treant.js
@@ -1282,15 +1282,15 @@
          * @param {object} nodeStructure
          * @returns {boolean}
          */
-		hasGrandChildren: function (nodeStructure) {
-		    var i = nodeStructure.children.length;
-		    while (i--) {
-		        if (nodeStructure.children[i].children && nodeStructure.children[i].children.length > 0) {
-		            return true;
-		        }
-		    }
-		    return false;
-		}
+	hasGrandChildren: function (nodeStructure) {
+	    var i = nodeStructure.children.length;
+	    while (i--) {
+	        if (nodeStructure.children[i].children && nodeStructure.children[i].children.length > 0) {
+	            return true;
+	        }
+	    }
+	    return false;
+	}
     };
 
     /**

--- a/Treant.js
+++ b/Treant.js
@@ -1282,15 +1282,15 @@
          * @param {object} nodeStructure
          * @returns {boolean}
          */
-        hasGrandChildren: function( nodeStructure ) {
-            var i = nodeStructure.children.length;
-            while ( i-- ) {
-                if ( nodeStructure.children[i].children ) {
-                    return true;
-                }
-            }
-            return false;
-        }
+		hasGrandChildren: function (nodeStructure) {
+		    var i = nodeStructure.children.length;
+		    while (i--) {
+		        if (nodeStructure.children[i].children && nodeStructure.children[i].children.length > 0) {
+		            return true;
+		        }
+		    }
+		    return false;
+		}
     };
 
     /**


### PR DESCRIPTION
Updated the hasGrandChildren function to return false if child has empty array of children in addition to being the case of children being falsey.  I ran into this issue when I loaded JSON nodes from a database.  The object properties were consistent across all nodes as they were all loaded from the same underlying class.  This left the end leaf nodes with a children property that was an empty array.  I had expected the stackChildren property to take effect since it was empty, but then realized it was just checking truthiness 
 which was preventing the stacking of the leaves.  With this very minor fix it seems to work now provided there are no actual grandchildren in the array and alleviates the need to alter the structure of the end leaf objects.   Great library!  Thanks!