### PR TITLE
fix for `positionTree` function

### DIFF
--- a/Treant.js
+++ b/Treant.js
@@ -497,7 +497,7 @@
         positionTree: function( callback ) {
             var self = this;
 
-            if ( this.imageLoader.isNotLoading() ) {
+            if ( !this.imageLoader.isNotLoading() ) {
                 var root = this.root(),
                     orient = this.CONFIG.rootOrientation;
 


### PR DESCRIPTION
if images are loaded, the `isNotLoading()` function returns `false`, not `true`.