### PR TITLE
Update generation of src url

### DIFF
--- a/Treant.js
+++ b/Treant.js
@@ -320,7 +320,7 @@
                 UTIL.addEvent( image, 'error', imgTrigger ); // handle broken url-s
 
                 // load event is not fired for cached images, force the load event
-                image.src += ( ( image.src.indexOf( '?' ) > 0)? '&': '?' ) + new Date().getTime();
+                image.src += ( ( image.src.indexOf( '?' ) > 0)? '&': '?' ) + new Date().getTime() + '=1';
             }
             else {
                 imgTrigger();


### PR DESCRIPTION
Some APIs don't accept a query parameter without a value.  This provides a value of 1 to the auto-generated query parameter for cached images.

Very minor change.